### PR TITLE
Python 2.6: str.decode() takes no keyword arguments

### DIFF
--- a/twitter_rss.py
+++ b/twitter_rss.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 class Tweet(object):
 
     def __init__(self, text, meta, get_pics=False):
-        self.raw_text = str(text).decode(encoding='UTF-8')
+        self.raw_text = str(text).decode('UTF-8')
         self.set_info(meta)
         self.get_pics = get_pics
 


### PR DESCRIPTION
Fixes "TypeError: decode() takes no keyword arguments" in Python 2.6

```
Python 2.6.6 (r266:84292, Dec 27 2010, 00:02:40) 
[GCC 4.4.5] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> "test".decode(encoding='UTF-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: decode() takes no keyword arguments
>>>
```
